### PR TITLE
Correcting calculation logic for asset size

### DIFF
--- a/pages/assetmanagement.tsx
+++ b/pages/assetmanagement.tsx
@@ -34,7 +34,9 @@ function ReleaseCard({ release }: { release: Release }) {
             <Typography fontSize={10}>
               {(
                 release.assets
-                  .filter((asset) => asset.cached)
+                  .filter((asset) => {
+                    return asset.cached && asset.build_type == 'ota';
+                  })
                   .reduce((totalSize, asset) => totalSize + asset.size, 0) /
                 (1024 * 1024)
               ).toFixed(2)}


### PR DESCRIPTION
Fix calculations to only include the cached ota assets.