### PR TITLE
ci: publish UI artifacts from a scratch image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,13 @@
 ARG NODE_VER="22-bookworm-slim"
 
-FROM node:${NODE_VER}
+FROM node:${NODE_VER} AS build
 WORKDIR /was-ui
-COPY . .
 
-RUN npm install
+COPY package.json package-lock.json ./
+RUN npm ci
+
+COPY . .
 RUN npm run build
 
-EXPOSE 3000
+FROM scratch AS artifact
+COPY --from=build /was-ui/out /out

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,8 +1,10 @@
-version: '3.1'
+version: '3.4'
 
 services:
   ui:
-    build: .
+    build:
+      context: .
+      target: build
     restart: unless-stopped
     ports:
       - '3000:3000'

--- a/utils.sh
+++ b/utils.sh
@@ -49,7 +49,7 @@ build)
 ;;
 
 build-docker|docker-build)
-    docker build -t "$TAG" -f Dockerfile .
+    docker build --target build -t "$TAG" -f Dockerfile .
 ;;
 
 install)


### PR DESCRIPTION
Build the Next.js export in a dedicated Node stage using npm ci so the committed lockfile controls the dependency graph and install layers can be cached independently of source changes.

Copy only /out into a scratch artifact stage for the image pushed by CI. Keep local Compose and utils.sh workflows on the Node build stage so development commands retain npm and the runtime.

Bump the Compose format to 3.4 because it adds support for build.target, which is needed to select the Node stage locally.