### PR TITLE
Dockerfile: restore original UI artifact path

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,4 +10,4 @@ COPY . .
 RUN npm run build
 
 FROM scratch AS artifact
-COPY --from=build /was-ui/out /out
+COPY --from=build /was-ui/out /was-ui/out


### PR DESCRIPTION
The scratch artifact image moved the static export from /was-ui/out to /out, breaking downstream consumers that rely on the established path.

Keep the minimal scratch image while restoring /was-ui/out for backward compatibility.

Fixes: 0cff3288dc62 ("ci: publish UI artifacts from a scratch image")