### PR TITLE
UI: warn when Willow requires a WAS upgrade

### DIFF
--- a/misc/model.ts
+++ b/misc/model.ts
@@ -14,6 +14,7 @@ export interface Release {
   assets: ReleaseAsset[];
   latest: boolean;
   prerelease: boolean;
+  was_compatible?: boolean;
 }
 
 export interface ReleaseAsset {

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,3 +1,5 @@
+import Alert from '@mui/material/Alert';
+import AlertTitle from '@mui/material/AlertTitle';
 import Grid from '@mui/material/Grid';
 import type { NextPage } from 'next';
 import { useRouter } from 'next/navigation';
@@ -6,7 +8,7 @@ import useSWR from 'swr';
 import ClientCard from '../components/ClientCard';
 import LeftMenu from '../components/LeftMenu';
 import { fetcher } from '../misc/fetchers';
-import { Client, Release } from '../misc/model';
+import { AdvancedSettings, Client, Release } from '../misc/model';
 import { OnboardingContext } from './_app';
 
 const Home: NextPage = () => {
@@ -16,7 +18,13 @@ const Home: NextPage = () => {
   }); //we refresh clients every 5 seconds so we can detect offline, new, & updated clients
   const onboardingContext = React.useContext(OnboardingContext);
   const { data: releaseData, error: releaseError } = useSWR<Release[]>('/api/release?type=was');
+  const { data: advancedSettings } = useSWR<AdvancedSettings>('/api/config?type=config');
   const [latestRelease, setLatestRelease] = React.useState<Release | undefined>(undefined);
+  const incompatibleRelease = releaseData?.find(
+    (release) =>
+      release.was_compatible === false &&
+      (!release.prerelease || advancedSettings?.show_prereleases)
+  );
 
   React.useEffect(() => {
     setLatestRelease((releaseData?.filter((release) => release.latest) ?? [undefined])[0]);
@@ -29,6 +37,16 @@ const Home: NextPage = () => {
   return (
     <LeftMenu>
       <Grid container spacing={2}>
+        {incompatibleRelease && (
+          <Grid item xs={12}>
+            <Alert severity="warning">
+              <AlertTitle>New Willow release available</AlertTitle>
+              Willow {incompatibleRelease.name}, featuring the new &quot;Hey Willow&quot; wake word,
+              requires SR model OTA support from a newer Willow Application Server. Upgrade WAS to
+              be able to install the new Willow release.
+            </Alert>
+          </Grid>
+        )}
         {clientData?.map((client: any) => (
           <React.Fragment key={client.hostname}>
             <Grid item md={4} sm={6} xs={12} lg={3}>


### PR DESCRIPTION
Show a prominent warning when Willow releases appear that require SR model OTA support.